### PR TITLE
Fix dimmed/grey tabs: remove GSAP opacity interference and improve inactive tab visibility

### DIFF
--- a/lords-script.js
+++ b/lords-script.js
@@ -265,7 +265,6 @@ function initializeAnimations() {
                 start: "top 80%"
             },
             x: -30,
-            opacity: 0,
             duration: 0.6,
             stagger: 0.1,
             ease: "power2.out"

--- a/lords-styles.css
+++ b/lords-styles.css
@@ -621,9 +621,9 @@ footer {
 }
 
 .comp-button {
-    background: rgba(67, 97, 238, 0.1);
+    background: rgba(67, 97, 238, 0.25);
     color: var(--light-text);
-    border: 1px solid var(--border-color);
+    border: 1px solid rgba(67, 97, 238, 0.5);
     border-radius: 8px;
     padding: 10px 20px;
     white-space: nowrap;
@@ -633,7 +633,7 @@ footer {
 }
 
 .comp-button:hover {
-    background-color: rgba(67, 97, 238, 0.2);
+    background-color: rgba(67, 97, 238, 0.4);
     border-color: var(--primary-color);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }


### PR DESCRIPTION
- Remove opacity:0 from GSAP comp-button animation to prevent tabs from being
  left invisible when ScrollTrigger doesn't fire at the right scroll position
- Increase inactive tab background from rgba(67,97,238,0.1) to 0.25 so tabs
  are clearly visible on dark background
- Update inactive tab border from dark #30363d to rgba(67,97,238,0.5) for
  better visual definition

https://claude.ai/code/session_01GozVg6iUoHwr1iReJJ5a1V