### PR TITLE
Fix tab layout: contain nav width and fix mobile overflow conflict

### DIFF
--- a/lords-styles.css
+++ b/lords-styles.css
@@ -579,6 +579,7 @@ footer {
     .comps-nav {
         flex-wrap: wrap;
         justify-content: center;
+        overflow-x: visible;
     }
 
     .comp-button {
@@ -599,6 +600,7 @@ footer {
 /* Composition Navigation */
 .comps-nav {
     display: flex;
+    width: 100%;
     overflow-x: auto;
     gap: 15px;
     padding: 15px 0;


### PR DESCRIPTION
- Add width: 100% to .comps-nav so it stays within its parent container
  instead of growing wider than the viewport (fixes tabs extending off-screen)
- Add overflow-x: visible in the mobile media query to resolve the conflict
  between flex-wrap: wrap and overflow-x: auto (fixes overlapping/clipped tabs)

https://claude.ai/code/session_01QP4AtQmQegiobodivwmG4W